### PR TITLE
Ajout de la dépendance à FrCore

### DIFF
--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -1,3 +1,1 @@
-
-
 Alias: CAT = http://terminology.hl7.org/CodeSystem/observation-category

--- a/input/fsh/StructureDefinition/TLSVObservation.fsh
+++ b/input/fsh/StructureDefinition/TLSVObservation.fsh
@@ -10,8 +10,7 @@ Description: "Profil de la ressource Observation dans le cadre de la télésurve
 * status ^short = "Statut de la mesure/réponse: final | corrected | entered-in-error"
 
 * category 0..* MS
-* category ^short = "(recommandé) Grande catégorie qui peut servir à identifier les différentes sources d'observations en télésurveillance: vital-sign : constantes physiologiques, signes vitaux, mesures | 
-survey : réponse à questionnaire ou score |  activity : activité physique (#pas, #longueurs de piscine, ...)"
+* category ^short = "(recommandé) Grande catégorie qui peut servir à identifier les différentes sources d'observations en télésurveillance: vital-sign : constantes physiologiques, signes vitaux, mesures | survey : réponse à questionnaire ou score |  activity : activité physique (#pas, #longueurs de piscine, ...)"
 * category from https://interop.esante.gouv.fr/ig/fhir/tlsv/ValueSet/TLSVCategory (required)
 
 * code 1..1

--- a/input/fsh/StructureDefinition/TLSVObservation.fsh
+++ b/input/fsh/StructureDefinition/TLSVObservation.fsh
@@ -4,47 +4,63 @@ Id: tlsv-observation
 Title: "Profil Observation pour la telesurveillance"
 Description: "Profil de la ressource Observation dans le cadre de la télésurveillance pour transmettre une information de questionnaire"
 * identifier 0..* MS
-* identifier ^short = "recommandé : identifiant métier unique attribué à cette mesure/réponse"
+* identifier ^short = "(recommandé) identifiant métier unique attribué à cette mesure/réponse"
 
 * status 1..1 
-* status ^short = "requis : statut de la mesure/réponse: final | corrected | entered-in-error"
+* status ^short = "Statut de la mesure/réponse: final | corrected | entered-in-error"
 
 * category 0..* MS
-* category ^short = "recommandé : Grande catégorie qui peut servir à identifier les différentes sources d'observations en télésurveillance: vital-sign : constantes physiologiques, signes vitaux, mesures | 
+* category ^short = "(recommandé) Grande catégorie qui peut servir à identifier les différentes sources d'observations en télésurveillance: vital-sign : constantes physiologiques, signes vitaux, mesures | 
 survey : réponse à questionnaire ou score |  activity : activité physique (#pas, #longueurs de piscine, ...)"
 * category from https://interop.esante.gouv.fr/ig/fhir/tlsv/ValueSet/TLSVCategory (required)
+
 * code 1..1
-* code ^short = "requis : le type précis d'observation"
+* code ^short = "Le code descriptif de l'observation"
+
 * subject 1..1
-* subject ^short = "requis : La référence au patient télésuivi : pointe vers la ressource Patient accessible sur un serveur ou présente dans le Bundle courant"
-* subject only Reference(Patient)
+* subject ^short = "La référence au patient télésuivi : pointe vers la ressource Patient accessible sur un serveur ou présente dans le Bundle courant"
+* subject only Reference(FRCorePatientProfile)
+
 * encounter 0..1
-* encounter ^short = "optionnel : référence à une visite d'un thérapeute au patient"
+* encounter ^short = "Référence à une visite d'un thérapeute au patient"
+
 * effective[x] 1..1
 * effective[x] only dateTime or Period
-* effective[x] ^short = "requis : le temps clinique ou physiologique de l'observation : par exemple la journée pour un comptage de pas, ou la date et heure de pesage"
+* effective[x] ^short = "Le temps clinique ou physiologique de l'observation : par exemple la journée pour un comptage de pas, ou la date et heure de pesage"
+
 * issued 0..1
-* issued ^short = "recommandé : date et heure de mise à disposition de cette version de l'observation"
+* issued ^short = "(recommandé) date et heure de mise à disposition de cette version de l'observation"
+
 * performer 0..*
-* performer ^short = "recommandé : La personne qui a réalisé l'observation, ou saisi ou validé le résultat (un professionnel de santé, un aidant, le patient ...)"
+* performer ^short = "(recommandé) La personne qui a réalisé l'observation, ou saisi ou validé le résultat (un professionnel de santé, un aidant, le patient ...)"
+
 * value[x] 0..1
-* value[x] ^short = "recommandé : le résultat de l'observation. En principe présent. Peut être absent pour signifier une question laissée sans réponse, ou pour effacer un résultat précédemment communiqué dans une version précédente de la ressource"
+* value[x] ^short = "(recommandé) le résultat de l'observation. En principe présent. Peut être absent pour signifier une question laissée sans réponse, ou pour effacer un résultat précédemment communiqué dans une version précédente de la ressource"
+
 * dataAbsentReason 0..1
-* dataAbsentReason ^short = "recommandé : à renseigner dans le cas où l'élément 'value' est absent"
+* dataAbsentReason ^short = "(recommandé) à renseigner dans le cas où l'élément 'value' est absent"
+
 * interpretation 0..*
-* interpretation ^short = "optionnel : utilisable pour représenter un niveau d'alerte déclenché par cette observation"
+* interpretation ^short = "Utilisable pour représenter un niveau d'alerte déclenché par cette observation"
+
 * note 0..* 
-* note ^short = "optionnel : commentaire sur cette observation"
+* note ^short = "Commentaire sur cette observation"
+
 * bodySite 0..1
-* bodySite ^short = "optionnel : partie du corps spécifiquement concernée par l'observation"
+* bodySite ^short = "Partie du corps spécifiquement concernée par l'observation"
+
 * method 0..1
-* method ^short = "optionnel : la méthode de mesure employée "
+* method ^short = "La méthode de mesure employée"
+
 * device 0..1
-* device ^short = "optionnel : le dispositif de mesure employé"
+* device ^short = "Le dispositif de mesure employé"
+
 * referenceRange 0..*
-* referenceRange ^short = "optionnel : un intervalle de référence applicable à ce patient pour cette observation"
+* referenceRange ^short = "Un intervalle de référence applicable à ce patient pour cette observation"
+
 * derivedFrom 0..*
-* derivedFrom ^short = "optionnel : la ou les ressources qui contiennent les réponses du questionnaire"
+* derivedFrom ^short = "La ou les ressources qui contiennent les réponses du questionnaire"
 * derivedFrom only Reference(QuestionnaireResponse or Observation)
+
 * component 0..*
-* component ^short = "conditionnel : présent pour certaines observations combinant deux mesures concomitantes (exemple pression artérielle systolique et diastolique), et dans ce cas l'élément Observation.value n'est en général pas présent"
+* component ^short = "(conditionnel) présent pour certaines observations combinant deux mesures concomitantes, et dans ce cas l'élément Observation.value n'est en général pas présent"

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -4,16 +4,20 @@
 
 <B>Bienvenue dans le guide d'implémentation des réponses aux questionnaires au format FHIR.</B>
 
-<blockquote class="stu-note">
+<!-- <blockquote class="stu-note">
 <p>
   <b>Attention !</b> Cet Implementation Guide est une version en concertation, elle n'est pas en version courante et risque de changer avant publication officielle. La version courante sera accessible ici : https://interop.esante.gouv.fr/ig/fhir/telesurveillance
 </p>
 <p>
     Ce guide d'implémentation a été fait en collaboration avec InteropSanté et est hors ci-sis.
 </p>
+</blockquote> -->
+
+<blockquote class="stu-note">
+<p>
+    Ce guide d'implémentation a été fait en collaboration avec InteropSanté et est hors ci-sis.
+</p>
 </blockquote>
-
-
 
 Ce guide a été conçu pour faciliter l'échange de données entre les solutions de télésurveillance et les systèmes d'informations hospitaliers (Dossier Patient Informatisé et Entrepôt de Données de Santé notamment).
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -5,3 +5,4 @@
 * Ajout narratif [20](https://github.com/ansforge/IG-fhir-telesurveillance/pull/20), [15](https://github.com/ansforge/IG-fhir-telesurveillance/pull/15), [9](https://github.com/ansforge/IG-fhir-telesurveillance/pull/9), [5](https://github.com/ansforge/IG-fhir-telesurveillance/pull/5), [1](https://github.com/ansforge/IG-fhir-telesurveillance/pull/1)
 * Ajout exemples [16](https://github.com/ansforge/IG-fhir-telesurveillance/pull/16)
 * Ajout profils et correctifs [8](https://github.com/ansforge/IG-fhir-telesurveillance/pull/8), [4](https://github.com/ansforge/IG-fhir-telesurveillance/pull/4)
+* Ajout dépendance à FrCore et correction narratif [23](https://github.com/ansforge/IG-fhir-telesurveillance/pull/8)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -15,7 +15,7 @@ releaseLabel: draft
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:
-  hl7.fhir.fr.core: 2.0.1
+  hl7.fhir.fr.core: 2.1.0
  
 
 parameters:


### PR DESCRIPTION
## Description des changements

* Suppression des mentions 'optionnel' et 'requis' des short car déjà définies au niveau des cardinalités (évite les doublons)
* Mise à jour de la dépendance FrCore à 2.1.0 et ajout du profil FrCorePatientProfile à Observation.subjet
* Ajout de saut de ligne à chaque attribut

## Preview

https://ansforge.github.io/IG-fhir-telesurveillance/nr-add-fr-deps/ig